### PR TITLE
Add `cache_alias` kwarg to allow using non-default cache

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,1 +1,2 @@
 - Peter Bengtsson (@peterbe)
+- Ben Spaulding (@benspaulding)

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,23 @@ returning ``True``.
         # won't be called more than once every 1000 seconds.
         send_tax_returns(request.user)
 
+``cache_alias``
+~~~~~~~~~~~~~~~
+
+The ``cache_alias`` argument allows you to use a cache other than the default.
+
+.. code-block:: python
+
+    # Given settings like:
+    # CACHES = {
+    #     'default': {...},
+    #     'other': {...},
+    # }
+
+    @cache_memoize(1000, cache_alias='other')
+    def myfunc(start, end):
+        return random.random()
+
 
 Cache invalidation
 ~~~~~~~~~~~~~~~~~~

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -1,7 +1,7 @@
 from functools import wraps
 
 import hashlib
-from django.core.cache import cache
+from django.core.cache import caches, DEFAULT_CACHE_ALIAS
 
 from django.utils.encoding import force_text, force_bytes
 
@@ -13,6 +13,7 @@ def cache_memoize(
     hit_callable=None,
     miss_callable=None,
     store_result=True,
+    cache_alias=DEFAULT_CACHE_ALIAS,
 ):
     """Decorator for memoizing function calls where we use the
     "local cache" to store the result.
@@ -26,6 +27,7 @@ def cache_memoize(
     :arg function miss_callable: Gets executed if key was *not* in cache.
     :arg bool store_result: If you know the result is not important, just
     that the cache blocked it from running repeatedly, set this to False.
+    :arg string cache_alias: The cache alias to use; defaults to 'default'.
 
     Usage::
 
@@ -79,6 +81,8 @@ def cache_memoize(
         def noop(*args):
             return args
         args_rewrite = noop
+    
+    cache = caches[cache_alias]
 
     def decorator(func):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,4 @@ import pytest
 def clear_cache():
     from django.core.cache import caches
     caches['default'].clear()
+    caches['locmem'].clear()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -61,5 +61,8 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': '127.0.0.1:11211',
-    }
+    },
+    'locmem': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
 }

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -181,3 +181,24 @@ def test_invalidate():
     function.invalidate(100)  # known args
     assert value != function(100)
     assert len(calls_made) == 2
+
+
+def test_cache_memoize_custom_alias():
+
+    calls_made = []
+
+    def runmeonce(a):
+        calls_made.append(a)
+        return a * 2
+
+    runmeonce_default = cache_memoize(10)(runmeonce)
+    runmeonce_locmem = cache_memoize(10, cache_alias='locmem')(runmeonce)
+
+    runmeonce_default(10)
+    assert len(calls_made) == 1
+    runmeonce_default(10)
+    assert len(calls_made) == 1
+    runmeonce_locmem(10)
+    assert len(calls_made) == 2
+    runmeonce_locmem(10)
+    assert len(calls_made) == 2


### PR DESCRIPTION
Thank you for this project. It is well written, documented, and tested, which made using and contributing to it simple. 🙇 

I found a case in my application where being able to use a non-default cache was necessary. Is this a feature you would like to have?