### PR TITLE
Fix colon mis-caching issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+dist: xenial
 language: python
 matrix:
   include:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      dist: xenial
     - python: pypy3
 cache: pip
 install:

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -1,9 +1,11 @@
 from functools import wraps
 
 import hashlib
+from urllib.parse import quote
+
 from django.core.cache import caches, DEFAULT_CACHE_ALIAS
 
-from django.utils.encoding import force_text, force_bytes
+from django.utils.encoding import force_bytes
 
 MARKER = object()
 
@@ -91,8 +93,8 @@ def cache_memoize(
     def decorator(func):
         def _default_make_cache_key(*args, **kwargs):
             cache_key = ":".join(
-                [force_text(x) for x in args_rewrite(*args)]
-                + [force_text("{}={}".format(k, v)) for k, v in kwargs.items()]
+                [quote(str(x)) for x in args_rewrite(*args)]
+                + [quote("{}={}".format(k, v)) for k, v in kwargs.items()]
             )
             return hashlib.md5(
                 force_bytes("cache_memoize" + (prefix or func.__name__) + cache_key)

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -39,6 +39,9 @@ def test_cache_memoize():
     runmeonce("A" * 200, "B" * 200, {"C" * 100: "D" * 100})
     assert len(calls_made) == 5
 
+
+def test_prefixes():
+    calls_made = []
     # different prefixes
     @cache_memoize(10, prefix="first")
     def foo(value):
@@ -51,9 +54,13 @@ def test_cache_memoize():
         return "ho"
 
     foo("hey")
+    assert len(calls_made) == 1
     bar("hey")
-    assert len(calls_made) == 7
+    assert len(calls_made) == 2
 
+
+def test_no_store_result():
+    calls_made = []
     # Test when you don't care about the result
     @cache_memoize(10, store_result=False, prefix="different")
     def returnnothing(a, b, k="bla"):
@@ -62,7 +69,7 @@ def test_cache_memoize():
 
     returnnothing(1, 2)
     returnnothing(1, 2)
-    assert len(calls_made) == 8
+    assert len(calls_made) == 1
 
 
 def test_cache_memoize_hit_miss_callables():


### PR DESCRIPTION
This PR fixes #32.

The fix itself is inspired by Django's `make_template_fragment_key`: https://github.com/django/django/blob/76b3fc5c8d8dffb441aaa08f75833888be2107af/django/core/cache/utils.py#L10