### PR TITLE
Add official support for Django 2.2 and 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ Compatibility
 
 * Python 3.4, 3.5, 3.6, 3.7
 
-* Django 1.11, 2.0, 2.1
+* Django 1.11, 2.0, 2.1, 2.2, 3.0
 
 Check out the `tox.ini`_ file for more up-to-date compatibility by
 test coverage.

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,18 @@ envlist =
     lint-py36,
     readme-py36,
     docs-py36,
-    py35-django{111,20,21},
-    py36-django{111,20,21},
-    py37-django{111,20,21},
-    pypy3-django{111,20,21},
+    py35-django{111,20,21,22},
+    py36-django{111,20,21,22,30},
+    py37-django{111,20,21,22,30},
+    py38-django{22,30},
+    pypy3-django{111,20,21,22},
 
 [testenv]
 basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 usedevelop = true
 setenv =
@@ -25,7 +27,9 @@ deps =
     -rtests/requirements.txt
     django111: Django >=1.11, <2.0
     django20: Django>=2.0,<2.1
-    django21: Django>=2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<3
+    django30: Django>=3.0
 commands =
     pytest {posargs:tests}
 


### PR DESCRIPTION
Tests are all passing for Django 2.2 and 3.0.
I think it's worth to mention that in the readme