### PR TITLE
Prevent clashing of function names in different modules

### DIFF
--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -97,7 +97,7 @@ def cache_memoize(
                 + [quote("{}={}".format(k, v)) for k, v in kwargs.items()]
             )
             return hashlib.md5(
-                force_bytes("cache_memoize" + (prefix or func.__name__) + cache_key)
+                force_bytes("cache_memoize" + (prefix or func.__qualname__) + cache_key)
             ).hexdigest()
 
         _make_cache_key = key_generator_callable or _default_make_cache_key

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -43,6 +43,7 @@ def test_cache_memoize():
 
 def test_prefixes():
     calls_made = []
+
     # different prefixes
     @cache_memoize(10, prefix="first")
     def foo(value):
@@ -62,6 +63,7 @@ def test_prefixes():
 
 def test_no_store_result():
     calls_made = []
+
     # Test when you don't care about the result
     @cache_memoize(10, store_result=False, prefix="different")
     def returnnothing(a, b, k="bla"):

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -190,7 +190,7 @@ def test_cache_memoize_different_functions_same_arguments():
     # If you set the prefix, you can cross wire functions.
     # Note sure why you'd ever want to do this though
 
-    @cache_memoize(10, prefix=function_2.__name__)
+    @cache_memoize(10, prefix=function_2.__qualname__)
     def function_3(a):
         raise Exception
 


### PR DESCRIPTION
Fixes #15

Hi @peterbe,

First of all I would like to thank you for your awesome library.

I found some problem using it in a project not so small, that some modules can have same function name and it's very tedious to set `prefix` all the time.

What do you think of the solution I propose using `__module__` (I know the tests are not passing)? I think that would fix a lot of cases, even if some would still remain (for example, objects with the same function name or inherited in the same module)

Kind regards and thank you for your work