### PR TITLE
Add support for caching exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ returning ``True``.
 This is useful if you have a function that can return an exception as valid
 result. This option allows you to cache said exceptions like any other result.
 Only exceptions raised from the list of classes provided as cache_exceptions
-are cached, all others are propagated immediatly.
+are cached, all others are propagated immediately.
 
 .. code-block:: python
 
@@ -239,7 +239,7 @@ are cached, all others are propagated immediatly.
     class InvalidParameter(Exception):
         pass
 
-    @cache_memoize(1000, cache_exceptions=[InvalidParameter])
+    @cache_memoize(1000, cache_exceptions=(InvalidParameter, ))
     def run_calculations(parameter):
         # something something time consuming
         ...

--- a/README.rst
+++ b/README.rst
@@ -227,29 +227,40 @@ returning ``True``.
 ``cache_exceptions``
 ~~~~~~~~~~~~~~~~~~~~
 
-This is useful if you have a function that can return an exception as valid
-result. This option allows you to cache said exceptions like any other result.
+This is useful if you have a function that can raise an exception as valid
+result. If the cached function raises any of specified exceptions is the
+exception cached and raised as normal. Subsequent cached calls will
+immediately re-raise the exception and the function will not be executed.
+``cache_exceptions`` accepts an Exception or a tuple of Exceptions.
+
+
+This option allows you to cache said exceptions like any other result.
 Only exceptions raised from the list of classes provided as cache_exceptions
 are cached, all others are propagated immediately.
 
 .. code-block:: python
 
-    from cache_memoize import cache_memoize
+    >>> from cache_memoize import cache_memoize
 
-    class InvalidParameter(Exception):
-        pass
+    >>> class InvalidParameter(Exception):
+    ...     pass
 
-    @cache_memoize(1000, cache_exceptions=(InvalidParameter, ))
-    def run_calculations(parameter):
-        # something something time consuming
-        ...
-        raise InvalidParameter
+    >>> @cache_memoize(1000, cache_exceptions=(InvalidParameter, ))
+    ... def run_calculations(parameter):
+    ...     # something something time consuming
+    ...     raise InvalidParameter
 
-    run_calculations(1)
+    >>> run_calculations(1)
+    Traceback (most recent call last):
+    ...
+    InvalidParameter
 
     # run_calculations will now raise InvalidParameter immediately
     # without running the expensive calculation
-    run_calculations(1)
+    >>> run_calculations(1)
+    Traceback (most recent call last):
+    ...
+    InvalidParameter
 
 ``cache_alias``
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -224,6 +224,33 @@ returning ``True``.
         # won't be called more than once every 1000 seconds.
         send_tax_returns(request.user)
 
+``cache_exceptions``
+~~~~~~~~~~~~~~~~~~~~
+
+This is useful if you have a function that can return an exception as valid
+result. This option allows you to cache said exceptions like any other result.
+Only exceptions raised from the list of classes provided as cache_exceptions
+are cached, all others are propagated immediatly.
+
+.. code-block:: python
+
+    from cache_memoize import cache_memoize
+
+    class InvalidParameter(Exception):
+        pass
+
+    @cache_memoize(1000, cache_exceptions=[InvalidParameter])
+    def run_calculations(parameter):
+        # something something time consuming
+        ...
+        raise InvalidParameter
+
+    run_calculations(1)
+
+    # run_calculations will now raise InvalidParameter immediately
+    # without running the expensive calculation
+    run_calculations(1)
+
 ``cache_alias``
 ~~~~~~~~~~~~~~~
 

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -34,7 +34,10 @@ def cache_memoize(
     :arg key_generator_callable: Custom cache key name generator.
     :arg bool store_result: If you know the result is not important, just
     that the cache blocked it from running repeatedly, set this to False.
-    :arg bool cache_exceptions: Any exception raised from classes provided in
+    :arg Exception cache_exceptions: Accepts an Exception or a tuple of
+    Exceptions. If the cached function raises any of these exceptions is the
+    exception cached and raised as normal. Subsequent cached calls will
+    immediately re-raise the exception and the function will not be executed.
     this tuple will be cached, all other will be propagated.
     :arg string cache_alias: The cache alias to use; defaults to 'default'.
 
@@ -125,11 +128,8 @@ def cache_memoize(
                 # catch it, else let it propagate.
                 try:
                     result = func(*args, **kwargs)
-                except Exception as exception:
-                    if isinstance(exception, cache_exceptions):
-                        result = exception
-                    else:
-                        raise exception
+                except cache_exceptions as exception:
+                    result = exception
 
                 if not store_result:
                     # Then the result isn't valuable/important to store but

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -18,7 +18,7 @@ def cache_memoize(
     miss_callable=None,
     key_generator_callable=None,
     store_result=True,
-    cache_exceptions=False,
+    cache_exceptions=None,
     cache_alias=DEFAULT_CACHE_ALIAS,
 ):
     """Decorator for memoizing function calls where we use the
@@ -34,8 +34,8 @@ def cache_memoize(
     :arg key_generator_callable: Custom cache key name generator.
     :arg bool store_result: If you know the result is not important, just
     that the cache blocked it from running repeatedly, set this to False.
-    :arg bool cache_exceptions: To store any raised exceptions in the cache
-    set this to True, to raise them immediately, set to False.
+    :arg bool cache_exceptions: Any exception raised from classes provided in
+    this list will be cached, all other will be propagated.
     :arg string cache_alias: The cache alias to use; defaults to 'default'.
 
     Usage::
@@ -124,7 +124,7 @@ def cache_memoize(
                 try:
                     result = func(*args, **kwargs)
                 except Exception as exception:
-                    if cache_exceptions:
+                    if exception.__class__ in (cache_exceptions or []):
                         result = exception
                     else:
                         raise exception
@@ -140,6 +140,9 @@ def cache_memoize(
                     miss_callable(*args, **kwargs)
             elif hit_callable:
                 hit_callable(*args, **kwargs)
+
+            if result.__class__ in (cache_exceptions or []):
+                raise result
             return result
 
         def invalidate(*args, **kwargs):

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -402,7 +402,10 @@ def test_cache_exceptions():
     calls_made = []
 
     # It should be possible to specify a tuple of exceptions to cache.
-    @cache_memoize(10, cache_exceptions=(TestException, SecondTestException), prefix="cache_exceptions")
+    @cache_memoize(
+        10, cache_exceptions=(TestException, SecondTestException),
+        prefix="cache_exceptions"
+    )
     def raise_test_exception():
         calls_made.append(1)
         raise TestException
@@ -446,4 +449,3 @@ def test_dont_cache_unrelated_exceptions():
     with pytest.raises(SecondTestException):
         raise_test_exception()
     assert len(calls_made) == 2
-

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -405,7 +405,7 @@ def test_cache_exceptions():
     @cache_memoize(
         10,
         cache_exceptions=(TestException, SecondTestException),
-        prefix="cache_exceptions"
+        prefix="cache_exceptions",
     )
     def raise_test_exception():
         calls_made.append(1)

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -403,7 +403,8 @@ def test_cache_exceptions():
 
     # It should be possible to specify a tuple of exceptions to cache.
     @cache_memoize(
-        10, cache_exceptions=(TestException, SecondTestException),
+        10,
+        cache_exceptions=(TestException, SecondTestException),
         prefix="cache_exceptions"
     )
     def raise_test_exception():

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -355,18 +355,18 @@ def test_cache_memoize_thread_safety():
 def test_cache_exceptions():
     calls_made = []
 
-    @cache_memoize(10, cache_exceptions=True, prefix="cache_exceptions")
-    def raise_test_exception(a):
-        calls_made.append(a)
-        raise Exception
+    @cache_memoize(10, cache_exceptions=[Exception], prefix="cache_exceptions")
+    def raise_test_exception(exception):
+        calls_made.append(exception)
+        raise exception
 
     try:
-        raise_test_exception(1)
+        raise_test_exception(Exception)
     except:
         pass
 
     try:
-        raise_test_exception(1)
+        raise_test_exception(Exception)
     except:
         pass
 
@@ -376,19 +376,69 @@ def test_cache_exceptions():
 def test_dont_cache_exceptions():
     calls_made = []
 
-    @cache_memoize(10, cache_exceptions=False, prefix="dont_cache_exceptions")
-    def raise_test_exception(a):
-        calls_made.append(a)
-        raise Exception
+    @cache_memoize(10, prefix="dont_cache_exceptions")
+    def raise_test_exception(exception):
+        calls_made.append(exception)
+        raise exception
 
     try:
-        raise_test_exception(1)
+        raise_test_exception(Exception)
     except:
         pass
 
     try:
-        raise_test_exception(1)
+        raise_test_exception(Exception)
     except:
         pass
 
     assert len(calls_made) == 2
+
+
+def test_cache_specific_exception():
+    calls_made = []
+
+    @cache_memoize(10, cache_exceptions=[IndexError], prefix="cache_specifc_exceptions")
+    def raise_test_exception(exception):
+        calls_made.append(exception)
+        raise exception
+
+    try:
+        raise_test_exception(Exception)
+    except:
+        pass
+
+    try:
+        raise_test_exception(IndexError)
+    except:
+        pass
+
+    try:
+        raise_test_exception(IndexError)
+    except:
+        pass
+
+    assert len(calls_made) == 2
+
+
+def test_exceptions_raised_not_returned():
+
+    @cache_memoize(10, cache_exceptions=[IndexError], prefix="cache_specifc_exceptions")
+    def raise_test_exception(exception):
+        raise exception
+
+    try:
+        a = raise_test_exception(Exception)
+    except:
+        a = 'raised'
+
+    try:
+        b = raise_test_exception(IndexError)
+    except:
+        b = 'raised'
+
+    try:
+        c = raise_test_exception(IndexError)
+    except:
+        c = 'raised'
+
+    assert a == 'raised' and b == 'raised' and  c == 'raised'

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -350,3 +350,45 @@ def test_cache_memoize_thread_safety():
         thread.join()
 
     assert len(calls_made) == 2
+
+
+def test_cache_exceptions():
+    calls_made = []
+
+    @cache_memoize(10, cache_exceptions=True, prefix="cache_exceptions")
+    def raise_test_exception(a):
+        calls_made.append(a)
+        raise Exception
+
+    try:
+        raise_test_exception(1)
+    except:
+        pass
+
+    try:
+        raise_test_exception(1)
+    except:
+        pass
+
+    assert len(calls_made) == 1
+
+
+def test_dont_cache_exceptions():
+    calls_made = []
+
+    @cache_memoize(10, cache_exceptions=False, prefix="dont_cache_exceptions")
+    def raise_test_exception(a):
+        calls_made.append(a)
+        raise Exception
+
+    try:
+        raise_test_exception(1)
+    except:
+        pass
+
+    try:
+        raise_test_exception(1)
+    except:
+        pass
+
+    assert len(calls_made) == 2


### PR DESCRIPTION
We have a usecase where we need to store the result of an fairly expensive function call, one that could raise an exception as a valid result. I ended up adding the option to cache exceptions as any other result, I figure this could be useful someone else as well.