### PR TITLE
Add get_cache_key method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build
 dist
 *.pyc
 django_cache_memoize.egg-info
+.venv
+.vscode

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -157,7 +157,12 @@ def cache_memoize(
             cache_key = _make_cache_key(*args, **kwargs)
             cache.delete(cache_key)
 
+        def get_cache_key(*args, **kwargs):
+            kwargs.pop("_refresh", None)
+            return _make_cache_key(*args, **kwargs)
+
         inner.invalidate = invalidate
+        inner.get_cache_key = get_cache_key
         return inner
 
     return decorator

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -243,6 +243,15 @@ def test_invalidate_with_refresh():
     assert len(calls_made) == 3
 
 
+def test_get_cache_key():
+    @cache_memoize(10)
+    def funky(argument):
+        pass
+
+    assert funky.get_cache_key(100) == "f0b86356861e088e2058855e95ee8981"
+    assert funky.get_cache_key(100, _refresh=True) == "f0b86356861e088e2058855e95ee8981"
+
+
 def test_cache_memoize_custom_alias():
 
     calls_made = []
@@ -307,6 +316,14 @@ def test_invalidate_with_custom_key_generator():
     runmeonce.invalidate(1, 2)  # known args
     assert runmeonce(1, 2)
     assert len(calls_made) == 2
+
+
+def test_get_cache_key_with_custom_key_generator():
+    @cache_memoize(10, key_generator_callable=lambda x: x * 10)
+    def funky(argument):
+        pass
+
+    assert funky.get_cache_key("1") == "1111111111"
 
 
 def test_cache_memoize_none_value():


### PR DESCRIPTION
Similar to `invalidate`, this adds a method to the decorated function to get the cache key

Fixes peterbe/django-cache-memoize#34