### PR TITLE
Remove support for unsupported Python/Django combinations.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,7 @@
 
 name: Python
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, "pypy3"]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "pypy3"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "pypy3"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist =
-    lint-py36,
-    readme-py36,
-    docs-py36,
+    lint-py39,
+    readme-py39,
+    docs-py39,
     py35-django{22},
     py36-django{22,31},
     py37-django{22,31},
     py38-django{22,31},
+    py39-django{22,31},
     pypy3-django{22,31},
 
 [gh-actions]
@@ -14,7 +15,8 @@ python =
   3.5: py35
   3.6: py36
   3.7: py37
-  3.8: py38, lint, restlint
+  3.8: py38
+  3.9: py39, lint, restlint
   pypy3: pypy3
 
 [testenv]
@@ -29,13 +31,13 @@ deps =
 commands =
     pytest {posargs:tests}
 
-[testenv:docs-py36]
+[testenv:docs-py39]
 deps =
     sphinx
 commands =
     docs: sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
-[testenv:readme-py36]
+[testenv:readme-py39]
 deps =
     twine
     readme_renderer[md]
@@ -43,6 +45,6 @@ commands =
     python setup.py sdist
     twine check dist/*
 
-[testenv:lint-py36]
+[testenv:lint-py39]
 extras = dev
 commands=therapist run --use-tracked-files

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist =
     lint-py36,
     readme-py36,
     docs-py36,
-    py35-django{111,20,21,22},
-    py36-django{111,20,21,22,30},
-    py37-django{111,20,21,22,30},
-    py38-django{22,30},
-    pypy3-django{111,20,21,22},
+    py35-django{22},
+    py36-django{22,31},
+    py37-django{22,31},
+    py38-django{22,31},
+    pypy3-django{22,31},
 
 [gh-actions]
 python =
@@ -24,11 +24,8 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -rtests/requirements.txt
-    django111: Django >=1.11, <2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<3
-    django30: Django>=3.0
+    django31: Django>=3.1,<3.2
 commands =
     pytest {posargs:tests}
 


### PR DESCRIPTION
Thanks for creating this great repo! This and django-fancy-cache have been tremendous additions to my sites. 

I noticed the tests weren't passing so making an attempt to fix that and remove support for old versions of Python/Django.