### PR TITLE
Fix cache key/0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 django_cache_memoize.egg-info
 .venv
 .vscode
+.idea

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -1,4 +1,5 @@
 from functools import wraps
+import itertools
 
 import hashlib
 from urllib.parse import quote
@@ -99,8 +100,13 @@ def cache_memoize(
     def decorator(func):
         def _default_make_cache_key(*args, **kwargs):
             cache_key = ":".join(
-                [quote(str(x)) for x in args_rewrite(*args)]
-                + [quote("{}={}".format(k, v)) for k, v in sorted(kwargs.items())]
+                itertools.chain(
+                    (quote(str(x)) for x in args_rewrite(*args)),
+                    (
+                        "{}={}".format(quote(k), quote(str(v)))
+                        for k, v in sorted(kwargs.items())
+                    ),
+                )
             )
             prefix_ = prefix or ".".join((func.__module__ or "", func.__qualname__))
             return hashlib.md5(

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -102,8 +102,9 @@ def cache_memoize(
                 [quote(str(x)) for x in args_rewrite(*args)]
                 + [quote("{}={}".format(k, v)) for k, v in kwargs.items()]
             )
+            prefix_ = prefix or ".".join((func.__module__ or "", func.__qualname__))
             return hashlib.md5(
-                force_bytes("cache_memoize" + (prefix or func.__qualname__) + cache_key)
+                force_bytes("cache_memoize" + prefix_ + cache_key)
             ).hexdigest()
 
         _make_cache_key = key_generator_callable or _default_make_cache_key

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -100,7 +100,7 @@ def cache_memoize(
         def _default_make_cache_key(*args, **kwargs):
             cache_key = ":".join(
                 [quote(str(x)) for x in args_rewrite(*args)]
-                + [quote("{}={}".format(k, v)) for k, v in kwargs.items()]
+                + [quote("{}={}".format(k, v)) for k, v in sorted(kwargs.items())]
             )
             prefix_ = prefix or ".".join((func.__module__ or "", func.__qualname__))
             return hashlib.md5(

--- a/tests/dummy_package/__init__.py
+++ b/tests/dummy_package/__init__.py
@@ -1,0 +1,12 @@
+import functools
+
+
+def dummy_decorator():
+    def _decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return _decorator

--- a/tests/dummy_package/a.py
+++ b/tests/dummy_package/a.py
@@ -1,0 +1,43 @@
+from cache_memoize import cache_memoize
+
+from . import dummy_decorator
+
+
+@cache_memoize(None)
+def func():
+    pass
+
+
+@cache_memoize(None)
+@dummy_decorator()
+def decorated_func():
+    pass
+
+
+@cache_memoize(None)
+def another_decorated_func():
+    pass
+
+
+def func_factory():
+    @cache_memoize(None)
+    def func():
+        pass
+
+    return func
+
+
+class DummyClass:
+    @cache_memoize(None)
+    def func(self):
+        pass
+
+    @cache_memoize(None)
+    @dummy_decorator()
+    def decorated_func(self):
+        pass
+
+    @cache_memoize(None)
+    @dummy_decorator()
+    def another_decorated_func(self):
+        pass

--- a/tests/dummy_package/b.py
+++ b/tests/dummy_package/b.py
@@ -1,0 +1,25 @@
+from cache_memoize import cache_memoize
+
+from . import dummy_decorator
+
+
+@cache_memoize(None)
+def func():
+    pass
+
+
+@cache_memoize(None)
+@dummy_decorator()
+def decorated_func():
+    pass
+
+
+class DummyClass:
+    @cache_memoize(None)
+    def func(self):
+        pass
+
+    @cache_memoize(None)
+    @dummy_decorator()
+    def decorated_func(self):
+        pass

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -22,26 +22,30 @@ def test_cache_memoize():
     calls_made = []
 
     @cache_memoize(10)
-    def runmeonce(a, b, k="bla"):
-        calls_made.append((a, b, k))
-        return "{} {} {}".format(a, b, k)  # sample implementation
+    def runmeonce(a, b, k1="bla", k2=None):
+        calls_made.append((a, b, k1, k2))
+        return "{} {} {} {}".format(a, b, k1, k2)  # sample implementation
 
     runmeonce(1, 2)
     runmeonce(1, 2)
     assert len(calls_made) == 1
     runmeonce(1, 3)
     assert len(calls_made) == 2
-    # should work with most basic types
+    # Should work with most basic types
     runmeonce(1.1, "foo")
     runmeonce(1.1, "foo")
     assert len(calls_made) == 3
-    # even more "advanced" types
-    runmeonce(1.1, "foo", k=list("åäö"))
-    runmeonce(1.1, "foo", k=list("åäö"))
+    # Even more "advanced" types
+    runmeonce(1.1, "foo", k1=list("åäö"))
+    runmeonce(1.1, "foo", k1=list("åäö"))
     assert len(calls_made) == 4
     # And shouldn't be a problem even if the arguments are really long
     runmeonce("A" * 200, "B" * 200, {"C" * 100: "D" * 100})
     assert len(calls_made) == 5
+    # The order of the keyword arguments doesn't matter
+    runmeonce(1, 2, k1=3, k2=4)
+    runmeonce(1, 2, k2=4, k1=3)
+    assert len(calls_made) == 6
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix some problems with the default cache key:
* functions with equal names may have equal cache keys (see [comment](https://github.com/peterbe/django-cache-memoize/pull/50#discussion_r619858926)). So, we should include module name in the cache key.
* we should sort `kwargs` dict when making cache key, so that the key of `f(a=1, b=2)` is guaranteed to be equal to the key of `f(b=2, a=1)`
* it is possible to pass string with equal sign as a key of the `kwargs` dict (see [comment](https://github.com/peterbe/django-cache-memoize/pull/50#discussion_r619858247)). We should not quote equal sign between key and value.