### PR TITLE
Add support for Django3.2 tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,9 +324,9 @@ certain pattern.
 Compatibility
 =============
 
-* Python 3.4, 3.5, 3.6, 3.7
+* Python 3.5, 3.6, 3.7, 3.8, 3.9
 
-* Django 1.11, 2.0, 2.1, 2.2, 3.0
+* Django 2.2, 3.0, 3.1, 3.2
 
 Check out the `tox.ini`_ file for more up-to-date compatibility by
 test coverage.

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Internet :: WWW/HTTP",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist =
     readme-py39,
     docs-py39,
     py35-django{22},
-    py36-django{22,31},
-    py37-django{22,31},
-    py38-django{22,31},
-    py39-django{22,31},
-    pypy3-django{22,31},
+    py36-django{22,31,32},
+    py37-django{22,31,32},
+    py38-django{22,31,32},
+    py39-django{22,31,32},
+    pypy3-django{22,31,32},
 
 [gh-actions]
 python =
@@ -28,6 +28,7 @@ deps =
     -rtests/requirements.txt
     django22: Django>=2.2,<3
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
 commands =
     pytest {posargs:tests}
 


### PR DESCRIPTION
## Description
- Added support in the `tox.ini` to run tests against `Django3.2`. 
- Updated the `Python` and `Django` versions mentioned in the `README.rst`.