### PR TITLE
feat: adds extra cache key components support

### DIFF
--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -31,7 +31,7 @@ def cache_memoize(
 
     :arg int timeout: Number of seconds to store the result if not None
     :arg string prefix: If None becomes the function name.
-    :arg string extra: Optional callable or serializable structure of key
+    :arg extra: Optional callable or serializable structure of key
     components cache should vary on.
     :arg function args_rewrite: Callable that rewrites the args first useful
     if your function needs nontrivial types but you know a simple way to

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -319,8 +319,8 @@ def test_get_cache_key():
     def funky(argument):
         pass
 
-    assert funky.get_cache_key(100) == "d33e7fad5d1d04da8e588a9ee348644a"
-    assert funky.get_cache_key(100, _refresh=True) == "d33e7fad5d1d04da8e588a9ee348644a"
+    assert funky.get_cache_key(100) == "eb96668ba0d14dc7748161fb1d000239"
+    assert funky.get_cache_key(100, _refresh=True) == "eb96668ba0d14dc7748161fb1d000239"
 
 
 def test_cache_memoize_custom_alias():
@@ -395,6 +395,21 @@ def test_get_cache_key_with_custom_key_generator():
         pass
 
     assert funky.get_cache_key("1") == "1111111111"
+
+
+def test_get_cache_key_with_extra_components():
+    def funky(argument):
+        pass
+
+    fn1 = cache_memoize(10, extra={"version": 1})(funky)
+    fn2 = cache_memoize(10, extra={"version": 1})(funky)
+    fn3 = cache_memoize(10, extra={"version": 2})(funky)
+    fn4 = cache_memoize(10, extra=lambda x: x * 2)(funky)
+    fn5 = cache_memoize(10, extra=lambda x: x * 3)(funky)
+
+    assert fn1.get_cache_key(1) == fn2.get_cache_key(1)
+    assert fn2.get_cache_key(1) != fn3.get_cache_key(1)
+    assert fn4.get_cache_key(1) != fn5.get_cache_key(1)
 
 
 def test_cache_memoize_none_value():


### PR DESCRIPTION
_I was surprised to find my own ticket here haha :)_ 

This feature allows to bind our memoized functions with external state. Extra argument can be anything json-serializable or even callable.

```python
@cache_memoize(60, extra=('foo', obj.pk, foo.last_updated_at))
def foo(*args, **kwargs):
    return 42

@cache_memoize(100, extra={"version": 2})
def callmeonce(arg1):
    print(arg1)

@cache_memoize(100, extra=100500)
def callmeonce(arg1):
    print(arg1)

@cache_memoize(100, extra=lambda user: user.is_staff)
def callmeonce(user):
    print(arg1)
```

Originally requested at #49 (solves #35 )