### PR TITLE
Add support for official Python & Django versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,13 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "pypy3"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -324,9 +324,9 @@ certain pattern.
 Compatibility
 =============
 
-* Python 3.5, 3.6, 3.7, 3.8, 3.9
+* Python 3.8, 3.9, 3.10 & 3.11
 
-* Django 2.2, 3.0, 3.1, 3.2
+* Django 3.2, 4.1 & 4.2
 
 Check out the `tox.ini`_ file for more up-to-date compatibility by
 test coverage.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ _here = path.dirname(__file__)
 
 setup(
     name="django-cache-memoize",
-    version="0.1.10",
+    version="0.2.0",
     description=(
         "Django utility for a memoization decorator that uses the Django "
         "cache framework."
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/peterbe/django-cache-memoize",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment :: Mozilla",
@@ -27,11 +27,10 @@ setup(
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Internet :: WWW/HTTP",
     ],

--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -130,7 +130,6 @@ def cache_memoize(
             else:
                 result = cache.get(cache_key, MARKER)
             if result is MARKER:
-
                 # If the function all raises an exception we want to cache,
                 # catch it, else let it propagate.
                 try:

--- a/tests/test_cache_memoize.py
+++ b/tests/test_cache_memoize.py
@@ -18,7 +18,6 @@ def test_the_setup():
 
 
 def test_cache_memoize():
-
     calls_made = []
 
     @cache_memoize(10)
@@ -166,7 +165,6 @@ class TestDefaultCacheKeyQuoting:
 
 
 def test_cache_memoize_hit_miss_callables():
-
     hits = []
     misses = []
     calls_made = []
@@ -208,7 +206,6 @@ def test_cache_memoize_hit_miss_callables():
 
 
 def test_cache_memoize_refresh():
-
     calls_made = []
 
     @cache_memoize(10)
@@ -225,7 +222,6 @@ def test_cache_memoize_refresh():
 
 
 def test_cache_memoize_different_functions_same_arguments():
-
     calls_made_1 = []
     calls_made_2 = []
 
@@ -271,7 +267,6 @@ def test_cache_memoize_different_functions_same_arguments():
 
 
 def test_invalidate():
-
     calls_made = []
 
     @cache_memoize(10)
@@ -291,7 +286,6 @@ def test_invalidate():
 
 
 def test_invalidate_with_refresh():
-
     calls_made = []
 
     @cache_memoize(10)
@@ -324,7 +318,6 @@ def test_get_cache_key():
 
 
 def test_cache_memoize_custom_alias():
-
     calls_made = []
 
     def runmeonce(a):
@@ -345,7 +338,6 @@ def test_cache_memoize_custom_alias():
 
 
 def test_cache_memoize_works_with_custom_key_generator():
-
     calls_made = []
 
     def key_generator(*args):
@@ -365,7 +357,6 @@ def test_cache_memoize_works_with_custom_key_generator():
 
 
 def test_invalidate_with_custom_key_generator():
-
     calls_made = []
 
     def key_generator(*args):

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,19 @@
 [tox]
 envlist =
-    lint-py39,
-    readme-py39,
-    docs-py39,
-    py35-django{22},
-    py36-django{22,31,32},
-    py37-django{22,31,32},
-    py38-django{22,31,32,40},
-    py39-django{22,31,32,40},
-    pypy3-django{22,31,32},
+    lint-py311,
+    readme-py311,
+    docs-py311,
+    py38-django{32,41,42},
+    py39-django{32,41,42},
+    py310-django{32,41,42},
+    py311-django{41,42},
 
 [gh-actions]
 python =
-  3.5: py35
-  3.6: py36
-  3.7: py37
-  3.8: py38
-  3.9: py39, lint, restlint
-  pypy3: pypy3
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311, lint, restlint
 
 [testenv]
 usedevelop = true
@@ -26,20 +22,19 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -rtests/requirements.txt
-    django22: Django>=2.2,<3
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<4.3
 commands =
     pytest {posargs:tests}
 
-[testenv:docs-py39]
+[testenv:docs-py311]
 deps =
     sphinx
 commands =
     docs: sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
-[testenv:readme-py39]
+[testenv:readme-py311]
 deps =
     twine
     readme_renderer[md]
@@ -47,6 +42,6 @@ commands =
     python setup.py sdist
     twine check dist/*
 
-[testenv:lint-py39]
+[testenv:lint-py311]
 extras = dev
 commands=therapist run --use-tracked-files


### PR DESCRIPTION
Hi @peterbe,

This PR
- adds support for Python 3.10 & 3.11
- adds support for Django 4.1 & 4.2
- update GitHub actions
- drop support for Python 3.5, 3.6 & 3.7 (EOL)
- drop support for Django 2.2, 3.0, 3.1
- drop pypy support
- addresses linting issues

Can we please have new release after this PR is merged?

Thanks,