### PR TITLE
feat: add default timout to `cache_memoize`

### DIFF
--- a/src/cache_memoize/__init__.py
+++ b/src/cache_memoize/__init__.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 
 from django.db import models
 from django.core.cache import caches, DEFAULT_CACHE_ALIAS
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 from django.utils.encoding import force_bytes
 
@@ -15,7 +16,7 @@ MARKER = object()
 
 
 def cache_memoize(
-    timeout,
+    timeout=DEFAULT_TIMEOUT,
     prefix=None,
     extra=None,
     args_rewrite=None,


### PR DESCRIPTION
In some cases, you do not want to specify the timout for all the definitions and want the method to use the django defult cache timeout instead.